### PR TITLE
updates documentation to fix typos

### DIFF
--- a/articles/queues.md
+++ b/articles/queues.md
@@ -257,9 +257,9 @@ Exclusive queues will be deleted when the connection they were
 declared on is closed.
 
 
-## Checking of an Queue Exists
+## Checking if a Queue Exists
 
-Sometimes it's convenient to check if an queue exists. To do so, at the protocol
+Sometimes it's convenient to check if a queue exists. To do so, at the protocol
 level you use `queue.declare` with `passive` seto to `true`. In response
 RabbitMQ responds with a channel exception if the queue does not exist.
 


### PR DESCRIPTION
- _a_ queue, not _an_ queue
- title meant to say _if_ not _of_
