### PR TITLE
Removed reference to deprecated Bunny::Queue#pop_as_hash function.

### DIFF
--- a/articles/queues.md
+++ b/articles/queues.md
@@ -1124,10 +1124,6 @@ The message properties are the same as those provided for delivery handlers (see
 
 If the queue is empty, then `[nil, nil, nil]` will be returned.
 
-There is another method, `Bunny::Queue#pop_as_hash`, that returns the message attributes as a hash -
-
-`{:header => properties, :payload => content, :delivery_details => delivery_info}`
-
 
 ## Unbinding Queues From Exchanges
 


### PR DESCRIPTION
Was following this guide and pop_as_hash kept blowing up, I finally realized it was removed in newer versions. 

These guides are quite well done so I wanted to help out and keep them up to date and clean. 
