### PR TITLE
Fix typo in the "Accessing Message Properties (Metadata)" example's code

### DIFF
--- a/articles/queues.md
+++ b/articles/queues.md
@@ -448,7 +448,7 @@ connection = Bunny.new
 connection.start
 
 ch = connection.create_channel
-q = connection.queue('', :exclusive => true)
+q = ch.queue('', :exclusive => true)
 x  = ch.default_exchange
 
 # set up the consumer


### PR DESCRIPTION
Trivial fix to make the example code work.