### PR TITLE
Add auth_mechanism config explanation

### DIFF
--- a/articles/connecting.md
+++ b/articles/connecting.md
@@ -47,6 +47,7 @@ Map options that Bunny will recognize are
  * `:network_recovery_interval` (number, default: ``): interval between reconnection attempts
  * `:threaded` (boolean): switches to single-threaded connections when set to `false`. Only recommended for apps that only publish messages.
  * `:continuation_timeout` (integer): timeout for client operations that expect a response (e.g. `Bunny::Queue#get`), in *milliseconds*. Default is `4000` ms.
+ * `:auth_mechanism` (string, default: `PLAIN`): Mechanism to authenticate with the server. Currently supporting `PLAIN` and `EXTERNAL`.
 
 plus TLS connection parameters covered in [Using TLS (SSL) Connections](/articles/tls.html).
 
@@ -74,7 +75,8 @@ Default connection parameters are
   :user      => "guest",
   :pass      => "guest",
   :heartbeat => :server, # will use RabbitMQ setting
-  :frame_max => 131072
+  :frame_max => 131072,
+  :auth_mechanism => "PLAIN"
 }
 ```
 


### PR DESCRIPTION
There're couple more configurations not yet in here but I don't know what they're doing, so I'll leave it to other people to write. E.g.
```
:recover_from_connection_close => false
:frame_max => 131072
:locale => "en_GB"
```