### PR TITLE
Mention issues with VPN and localhost

### DIFF
--- a/articles/troubleshooting.md
+++ b/articles/troubleshooting.md
@@ -101,7 +101,9 @@ Handling and logging them will likely reveal an issue when it arises.
 
 
 
-## Testing Network Connection with RabbitMQ using Telnet
+## Network connection issues
+
+### Testing Network Connection with RabbitMQ using Telnet
 
 One simple way to check network connection between a particular network node and a RabbitMQ node is to use `telnet`:
 
@@ -132,6 +134,10 @@ reasons, but it is a good idea to check these two things first:
 
  * Firewall configuration for port 5672 or 5671 (if TLS/SSL is used)
  * DNS resolution (if hostname is used)
+
+### Connecting to localhost on VPN
+
+Using VPN almost certainly changes your DNS server configuration which may affect connections to `localhost` as well as to remote hosts. If you keep getting `Got an exception when receiving data: IO timeout when reading 7 bytes (Timeout::Error)` errors and you're on VPN try switching VPN off.
 
 
 ## RabbitMQ Startup Issues


### PR DESCRIPTION
I got a lot of `Got an exception when receiving data: IO timeout when reading 7 bytes (Timeout::Error)` exceptions when trying to run Bunny tests on master. After some time I bumped into [this issue](https://github.com/ruby-amqp/bunny/issues/277). Turning off VPN solved the problem. I think it's worth to mention it in the "troubleshooting" section.

It would be nice to add an explanation of VPN issues to the doc, but I'm not sure what is the reason behind this bug,  `tcpdump` shows packets flowing between `localhost:5672` and the Ruby test process with Ruby process forcefully closing the connection and reconnecting.

`host localhost` shows with VPN on:

    localhost has address 127.0.0.1
    localhost has IPv6 address ::1

VPN off:

    localhost has address 127.0.0.1

However `tcpdump` shows packets going through IPv4 (`127.0.0.1.5672`).