### PR TITLE
Separate creating connection expressions

### DIFF
--- a/articles/connecting.md
+++ b/articles/connecting.md
@@ -273,7 +273,9 @@ if defined?(PhusionPassenger) # otherwise it breaks rake commands if you put thi
     if forked
        # We’re in a smart spawning mode
        # Now is a good time to connect to RabbitMQ
-       $rabbitmq_connection = Bunny.new; $rabbitmq_connection.start
+       $rabbitmq_connection = Bunny.new
+       $rabbitmq_connection.start
+       
        $rabbitmq_channel    = $rabbitmq_connection.create_channel
     end
   end


### PR DESCRIPTION
At first glance reading these docs, having the initialization and start of a connection on the same line was confusing for me. This PR moves those expressions onto their own lines similar to what the Unicorn example does.