### PR TITLE
Fix internal links

### DIFF
--- a/articles/community.md
+++ b/articles/community.md
@@ -7,8 +7,8 @@ layout: article
 
 [Bunny has a mailing list](https://groups.google.com/group/ruby-amqp). We
 encourage you to also join the
-[rabbitmq-discuss](https://lists.rabbitmq.com/cgi-bin/mailman/listinfo/rabbitmq-discuss)
-mailing list. Feel free to ask any questions that you may have.
+[Ruby RabbitMQ Libraries](https://groups.google.com/forum/#!forum/ruby-amqp)
+google group. Feel free to ask any questions that you may have.
 
 
 ## IRC

--- a/articles/concurrency.md
+++ b/articles/concurrency.md
@@ -152,7 +152,7 @@ guides](/articles/guides.html), covering various topics.
 We recommend that you read the following guides first, if possible, in
 this order:
 
- * [RabbitMQ Extensions to AMQP 0.9.1](/articles/rabbitmq_extensions.html)
+ * [RabbitMQ Extensions to AMQP 0.9.1](/articles/extensions.html)
  * [Error Handling and Recovery](/articles/error_handling.html)
  * [Troubleshooting](/articles/troubleshooting.html)
  * [Using TLS (SSL) Connections](/articles/tls.html)

--- a/articles/connecting.md
+++ b/articles/connecting.md
@@ -372,7 +372,7 @@ this order:
  * [Queues and Consumers](/articles/queues.html)
  * [Exchanges and Publishing](/articles/exchanges.html)
  * [Bindings](/articles/bindings.html)
- * [RabbitMQ Extensions to AMQP 0.9.1](/articles/rabbitmq_extensions.html)
+ * [RabbitMQ Extensions to AMQP 0.9.1](/articles/extensions.html)
  * [Durability and Related Matters](/articles/durability.html)
  * [Error Handling and Recovery](/articles/error_handling.html)
  * [Troubleshooting](/articles/troubleshooting.html)

--- a/articles/exchanges.md
+++ b/articles/exchanges.md
@@ -1207,7 +1207,7 @@ We recommend that you read the following guides first, if possible, in
 this order:
 
  * [Bindings](/articles/bindings.html)
- * [RabbitMQ Extensions to AMQP 0.9.1](/articles/rabbitmq_extensions.html)
+ * [RabbitMQ Extensions to AMQP 0.9.1](/articles/extensions.html)
  * [Durability and Related Matters](/articles/durability.html)
  * [Error Handling and Recovery](/articles/error_handling.html)
  * [Concurrency Considerations](/articles/concurrency.html)

--- a/articles/extensions.md
+++ b/articles/extensions.md
@@ -104,7 +104,7 @@ In some situations it is essential that messages are reliably delivered to the R
 
 The [Publisher Confirms AMQP extension](http://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms/) was designed to solve the reliable publishing problem in a more lightweight way compared to transactions.
 
-Publisher confirms are similar to message acknowledgements (documented in the [Queues and Consumers](/articles/queues/) guide), but involve
+Publisher confirms are similar to message acknowledgements (documented in the [Queues and Consumers](/articles/queues.html) guide), but involve
 a publisher and a RabbitMQ node instead of a consumer and a RabbitMQ node.
 
 ![RabbitMQ Message Acknowledgements](https://github.com/ruby-amqp/amqp/raw/master/docs/diagrams/006_amqp_091_message_acknowledgements.png)

--- a/articles/queues.md
+++ b/articles/queues.md
@@ -1029,7 +1029,7 @@ provides an AMQP 0.9.1 extension known as [negative
 acknowledgements](http://www.rabbitmq.com/extensions.html#negative-acknowledgements)
 (nacks) and Bunny supports this extension. For more information,
 please refer to the [RabbitMQ Extensions
-guide](/articles/rabbitmq_extensions.html).
+guide](/articles/extensions.html).
 
 ### QoS — Prefetching messages
 
@@ -1257,7 +1257,7 @@ See [Durability guide](/articles/durability.html)
 
 ## RabbitMQ Extensions Related to Queues
 
-See [RabbitMQ Extensions guide](/articles/rabbitmq_extensions.html)
+See [RabbitMQ Extensions guide](/articles/extensions.html)
 
 
 ## Wrapping Up
@@ -1286,7 +1286,7 @@ this order:
 
  * [Exchanges and Publishing](/articles/exchanges.html)
  * [Bindings](/articles/bindings.html)
- * [RabbitMQ Extensions to AMQP 0.9.1](/articles/rabbitmq_extensions.html)
+ * [RabbitMQ Extensions to AMQP 0.9.1](/articles/extensions.html)
  * [Durability and Related Matters](/articles/durability.html)
  * [Error Handling and Recovery](/articles/error_handling.html)
  * [Concurrency Considerations](/articles/concurrency.html)


### PR DESCRIPTION
The mailing list was replaced with the new google group and running `bundle exec jekyll build && htmlproofer --disable-external --assume-extension ./_site` I found several broken internal links which are now fixed