### PR TITLE
Remove warning about Ubuntu 11.10

### DIFF
--- a/articles/getting_started.md
+++ b/articles/getting_started.md
@@ -48,12 +48,6 @@ the RabbitMQ team provides.
 For RPM-based distributions like RedHat or CentOS, the RabbitMQ team
 provides an [RPM package](http://www.rabbitmq.com/install.html#rpm).
 
-<div class="alert alert-error"><strong>Note:</strong> The RabbitMQ
-packages that ship with Ubuntu versions earlier than 11.10 are
-outdated and <strong>will not work with Bunny 0.9.0 and later
-versions</strong> (you will need at least RabbitMQ v2.0 for use with
-this guide).</div>
-
 ## Installing Bunny
 
 ### Make sure that you have Ruby and [Rubygems](http://docs.rubygems.org/read/chapter/3) installed


### PR DESCRIPTION
Ubuntu 11.10 is nearly 10 years old now.

Ubuntu 14.04 is the oldest Ubuntu still in any type of support
https://wiki.ubuntu.com/Releases

As such, I do not think the warning about Ubuntu 11.10 is relevant any longer.

RabbitMQ v2 was released on 24 August 2010
https://www.rabbitmq.com/versions.html

I don't think it makes sense to worry about people running older versions today.